### PR TITLE
Save default pattern when generating algs

### DIFF
--- a/2x2/Cube2x2.py
+++ b/2x2/Cube2x2.py
@@ -122,6 +122,7 @@ def gen_all_algs(depth, print_progress = False):
             print(f"Genning algs of length {i}...")
         ai = alg_index(i)
         start_alg = str(ai)
+        all_algs.append(str(ai))
         ai.increment()
         while str(ai) != start_alg:
             all_algs.append(str(ai))


### PR DESCRIPTION
Added a line to save the initial alg index before incrementing. With the current behavior the alg index is incremented before adding the initial pattern, causing algs like U to not be saved. This results in the solution for U to be F2 U2 F2 U2 F2 U.